### PR TITLE
A return type was mislabeled

### DIFF
--- a/src/SubscribePro/Service/Subscription/Subscription.php
+++ b/src/SubscribePro/Service/Subscription/Subscription.php
@@ -536,7 +536,7 @@ class Subscription extends DataObject implements SubscriptionInterface
     }
 
     /**
-     * @return string[]
+     * @return mixed[]
      */
     public function getPlatformSpecificFields()
     {

--- a/src/SubscribePro/Service/Subscription/SubscriptionInterface.php
+++ b/src/SubscribePro/Service/Subscription/SubscriptionInterface.php
@@ -315,7 +315,7 @@ interface SubscriptionInterface extends DataInterface
     public function setUserDefinedFields(array $userDefinedFields);
 
     /**
-     * @return string[]
+     * @return mixed[]
      */
     public function getPlatformSpecificFields();
 


### PR DESCRIPTION
The get platform specific fields returns a multidimensional array and not an array of strings like I had though.