### PR TITLE
adds loading of all paginated subscriptions

### DIFF
--- a/src/SubscribePro/Service/Subscription/SubscriptionInterface.php
+++ b/src/SubscribePro/Service/Subscription/SubscriptionInterface.php
@@ -50,6 +50,7 @@ interface SubscriptionInterface extends DataInterface
     const CREATED = 'created';
     const UPDATED = 'updated';
     const CANCELLED = 'cancelled';
+    const PAGINATION_DEFAULT = 25;
 
     /**
      * Subscription statuses

--- a/tests/Service/Subscription/SubscriptionServiceTest.php
+++ b/tests/Service/Subscription/SubscriptionServiceTest.php
@@ -155,7 +155,7 @@ class SubscriptionServiceTest extends \PHPUnit_Framework_TestCase
             ],
             'Loading by customer ID' => [
                 'customerId' => 122,
-                'filters' => [SubscriptionInterface::CUSTOMER_ID => 122],
+                'filters' => [SubscriptionInterface::CUSTOMER_ID => 122, 'since_id' => 0],
                 'itemsData' => [[SubscriptionInterface::CUSTOMER_ID => 122, SubscriptionInterface::ID => 333]]
             ],
         ];


### PR DESCRIPTION
Loads subsequent paginated subscriptions when customer has gone over the the default page of 25 items.