### PR TITLE
Support for order details endpoints and _meta[order_details] fields

### DIFF
--- a/src/SubscribePro/Service/OrderDetails/OrderDetails.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetails.php
@@ -4,6 +4,25 @@ namespace SubscribePro\Service\OrderDetails;
 
 use SubscribePro\Service\DataObject;
 
-class OrderDetails extends DataObject
+class OrderDetails extends DataObject implements OrderDetailsInterface
 {
+    /**
+     * @param array $data
+     * @return $this
+     */
+    public function importData(array $data = [])
+    {
+        $this->data['order_details'] = $data;
+        return $this;
+    }
+
+    public function getOrderDetails()
+    {
+        return $this->getData(self::ORDER_DETAILS);
+    }
+
+    public function setOrderDetails(array $orderDetails)
+    {
+        return $this->setData(self::ORDER_DETAILS, $orderDetails);
+    }
 }

--- a/src/SubscribePro/Service/OrderDetails/OrderDetails.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetails.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SubscribePro\Service\OrderDetails;
+
+use SubscribePro\Service\DataObject;
+
+class OrderDetails extends DataObject
+{
+}

--- a/src/SubscribePro/Service/OrderDetails/OrderDetails.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetails.php
@@ -12,7 +12,7 @@ class OrderDetails extends DataObject implements OrderDetailsInterface
      */
     public function importData(array $data = [])
     {
-        $this->data['order_details'] = $data;
+        $this->data[self::ORDER_DETAILS] = $data;
         return $this;
     }
 

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsFactory.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsFactory.php
@@ -32,14 +32,4 @@ class OrderDetailsFactory implements DataFactoryInterface
     {
         return new $this->instanceName($data);
     }
-
-    /**
-     * @param array $data
-     * @param string $field
-     * @return mixed[]
-     */
-    protected function getFieldData($data, $field)
-    {
-        return !empty($data[$field]) ? $data[$field] : [];
-    }
 }

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsFactory.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SubscribePro\Service\OrderDetails;
+
+use SubscribePro\Service\DataFactoryInterface;
+use SubscribePro\Exception\InvalidArgumentException;
+
+/**
+ * @codeCoverageIgnore
+ */
+class OrderDetailsFactory implements DataFactoryInterface
+{
+    /**
+     * @var string
+     */
+    protected $instanceName;
+
+    /**
+     * @param string $instanceName
+     */
+    public function __construct(
+        $instanceName = '\SubscribePro\Service\OrderDetails\OrderDetails'
+    ) {
+        $this->instanceName = $instanceName;
+    }
+
+    /**
+     * @param array $data
+     * @return \SubscribePro\Service\Subscription\SubscriptionInterface
+     */
+    public function create(array $data = [])
+    {
+        return new $this->instanceName($data);
+    }
+
+    /**
+     * @param array $data
+     * @param string $field
+     * @return mixed[]
+     */
+    protected function getFieldData($data, $field)
+    {
+        return !empty($data[$field]) ? $data[$field] : [];
+    }
+}

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsInterface.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SubscribePro\Service\OrderDetails;
+
+use SubscribePro\Service\DataInterface;
+
+interface OrderDetailsInterface extends DataInterface
+{
+    /**
+     * Data fields
+     */
+    const ORDER_DETAILS = 'order_details';
+
+    /**
+     * @return mixed[]
+     */
+    public function getOrderDetails();
+
+    /**
+     * @param array $orderDetails
+     * @return mixed
+     */
+    public function setOrderDetails(array $orderDetails);
+}

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SubscribePro\Service\OrderDetails;
+
+use SubscribePro\Service\AbstractService;
+
+class OrderDetailsService extends AbstractService
+{
+    const NAME = 'order_details';
+
+    CONST API_NAME_ORDER_DETAILS = 'order_details';
+
+    /**
+     * @param OrderDetails $orderDetails
+     * @return \SubscribePro\Service\DataInterface
+     */
+    public function createSalesOrder(OrderDetails $orderDetails)
+    {
+        $response = $this->httpClient->post('/services/v2/order-details.json', [
+            self::API_NAME_ORDER_DETAILS => json_decode(json_encode($orderDetails), true),
+        ]);
+        return $this->retrieveItem($response, self::API_NAME_ORDER_DETAILS);
+    }
+
+    /**
+     * @param OrderDetails $orderDetails
+     * @return \SubscribePro\Service\DataInterface
+     */
+    public function createOrUpdateSalesOrder(OrderDetails $orderDetails)
+    {
+        $response = $this->httpClient->post('services/v2/order-details/create-or-update.json', [
+            self::API_NAME_ORDER_DETAILS => $orderDetails,
+        ]);
+        return $this->retrieveItem($response, self::API_NAME_ORDER_DETAILS);;
+    }
+}

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
@@ -14,9 +14,9 @@ class OrderDetailsService extends AbstractService
      * @param array $orderDetails
      * @return \SubscribePro\Service\OrderDetails\OrderDetailsInterface
      */
-    public function createOrderDetails(array $orderDetails = [])
+    public function createOrderDetails(array $orderDetailsData = [])
     {
-        return $this->dataFactory->create($data);
+        return $this->dataFactory->create($orderDetailsData);
     }
 
     /**

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
@@ -17,7 +17,7 @@ class OrderDetailsService extends AbstractService
     public function createSalesOrder(OrderDetails $orderDetails)
     {
         $response = $this->httpClient->post('/services/v2/order-details.json', [
-            self::API_NAME_ORDER_DETAILS => json_decode(json_encode($orderDetails), true),
+            self::API_NAME_ORDER_DETAILS => $orderDetails->toArray(),
         ]);
         return $this->retrieveItem($response, self::API_NAME_ORDER_DETAILS);
     }
@@ -29,7 +29,7 @@ class OrderDetailsService extends AbstractService
     public function createOrUpdateSalesOrder(OrderDetails $orderDetails)
     {
         $response = $this->httpClient->post('services/v2/order-details/create-or-update.json', [
-            self::API_NAME_ORDER_DETAILS => $orderDetails,
+            self::API_NAME_ORDER_DETAILS => $orderDetails->toArray(),
         ]);
         return $this->retrieveItem($response, self::API_NAME_ORDER_DETAILS);;
     }

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
@@ -11,13 +11,22 @@ class OrderDetailsService extends AbstractService
     CONST API_NAME_ORDER_DETAILS = 'order_details';
 
     /**
+     * @param array $orderDetails
+     * @return \SubscribePro\Service\OrderDetails\OrderDetailsInterface
+     */
+    public function createOrderDetails(array $orderDetails = [])
+    {
+        return $this->dataFactory->create($data);
+    }
+
+    /**
      * @param OrderDetails $orderDetails
      * @return \SubscribePro\Service\DataInterface
      */
     public function saveNewOrderDetails(OrderDetails $orderDetails)
     {
         $response = $this->httpClient->post('/services/v2/order-details.json', [
-            self::API_NAME_ORDER_DETAILS => $orderDetails->toArray(),
+            self::API_NAME_ORDER_DETAILS => $orderDetails->getOrderDetails(),
         ]);
         return $this->retrieveItem($response, self::API_NAME_ORDER_DETAILS);
     }
@@ -29,7 +38,7 @@ class OrderDetailsService extends AbstractService
     public function saveNewOrUpdateExistingOrderDetails(OrderDetails $orderDetails)
     {
         $response = $this->httpClient->post('services/v2/order-details/create-or-update.json', [
-            self::API_NAME_ORDER_DETAILS => $orderDetails->toArray(),
+            self::API_NAME_ORDER_DETAILS => $orderDetails->getOrderDetails(),
         ]);
         return $this->retrieveItem($response, self::API_NAME_ORDER_DETAILS);;
     }

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsService.php
@@ -14,7 +14,7 @@ class OrderDetailsService extends AbstractService
      * @param OrderDetails $orderDetails
      * @return \SubscribePro\Service\DataInterface
      */
-    public function createSalesOrder(OrderDetails $orderDetails)
+    public function saveNewOrderDetails(OrderDetails $orderDetails)
     {
         $response = $this->httpClient->post('/services/v2/order-details.json', [
             self::API_NAME_ORDER_DETAILS => $orderDetails->toArray(),
@@ -26,7 +26,7 @@ class OrderDetailsService extends AbstractService
      * @param OrderDetails $orderDetails
      * @return \SubscribePro\Service\DataInterface
      */
-    public function createOrUpdateSalesOrder(OrderDetails $orderDetails)
+    public function saveNewOrUpdateExistingOrderDetails(OrderDetails $orderDetails)
     {
         $response = $this->httpClient->post('services/v2/order-details/create-or-update.json', [
             self::API_NAME_ORDER_DETAILS => $orderDetails->toArray(),

--- a/src/SubscribePro/Service/OrderDetails/OrderDetailsServiceFactory.php
+++ b/src/SubscribePro/Service/OrderDetails/OrderDetailsServiceFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SubscribePro\Service\OrderDetails;
+
+use SubscribePro\Service\AbstractService;
+use SubscribePro\Service\AbstractServiceFactory;
+
+/**
+ * @codeCoverageIgnore
+ */
+class OrderDetailsServiceFactory extends AbstractServiceFactory
+{
+    /**
+     * @return \SubscribePro\Service\AbstractService
+     */
+    public function create()
+    {
+        return new OrderDetailsService(
+            $this->httpClient,
+            $this->createDataFactory(),
+            $this->config
+        );
+    }
+
+    /**
+     * @return \SubscribePro\Service\DataFactoryInterface
+     */
+    protected function createDataFactory()
+    {
+        return new OrderDetailsFactory();
+    }
+}

--- a/src/SubscribePro/Service/Subscription/SubscriptionService.php
+++ b/src/SubscribePro/Service/Subscription/SubscriptionService.php
@@ -2,6 +2,7 @@
 
 namespace SubscribePro\Service\Subscription;
 
+use SubscribePro\Exception\InvalidArgumentException;
 use SubscribePro\Service\AbstractService;
 
 /**
@@ -24,6 +25,7 @@ class SubscriptionService extends AbstractService
 
     const API_NAME_SUBSCRIPTION = 'subscription';
     const API_NAME_SUBSCRIPTIONS = 'subscriptions';
+    const API_NAME_META = '_meta';
 
     /**
      * @param array $subscriptionData
@@ -35,15 +37,25 @@ class SubscriptionService extends AbstractService
     }
 
     /**
-     * @param \SubscribePro\Service\Subscription\SubscriptionInterface $subscription
-     * @return \SubscribePro\Service\Subscription\SubscriptionInterface
+     * @param SubscriptionInterface $subscription
+     * @param array|null $_meta
+     * @return SubscriptionInterface
      * @throws \SubscribePro\Exception\EntityInvalidDataException
      * @throws \SubscribePro\Exception\HttpException
      */
-    public function saveSubscription(SubscriptionInterface $subscription)
+    public function saveSubscription(SubscriptionInterface $subscription, array $_meta = null)
     {
         $url = $subscription->isNew() ? '/services/v2/subscription.json' : "/services/v2/subscriptions/{$subscription->getId()}.json";
-        $response = $this->httpClient->post($url, [self::API_NAME_SUBSCRIPTION => $subscription->getFormData()]);
+        $payload = [
+            self::API_NAME_SUBSCRIPTION => $subscription->getFormData()
+        ];
+        if (null !== $_meta) {
+            if (!is_array($_meta)) {
+                throw new InvalidArgumentException('The _meta data passed to the subscription must be an array.');
+            }
+            $payload[self::API_NAME_META] = $_meta;
+        }
+        $response = $this->httpClient->post($url, $payload);
         return $this->retrieveItem($response, self::API_NAME_SUBSCRIPTION, $subscription);
     }
 

--- a/src/SubscribePro/Service/Subscription/SubscriptionService.php
+++ b/src/SubscribePro/Service/Subscription/SubscriptionService.php
@@ -38,22 +38,17 @@ class SubscriptionService extends AbstractService
 
     /**
      * @param SubscriptionInterface $subscription
-     * @param array|null $_meta
+     * @param array|null $metadata
      * @return SubscriptionInterface
      * @throws \SubscribePro\Exception\EntityInvalidDataException
      * @throws \SubscribePro\Exception\HttpException
      */
-    public function saveSubscription(SubscriptionInterface $subscription, array $_meta = null)
+    public function saveSubscription(SubscriptionInterface $subscription, array $metadata = null)
     {
         $url = $subscription->isNew() ? '/services/v2/subscription.json' : "/services/v2/subscriptions/{$subscription->getId()}.json";
-        $payload = [
-            self::API_NAME_SUBSCRIPTION => $subscription->getFormData()
-        ];
-        if (null !== $_meta) {
-            if (!is_array($_meta)) {
-                throw new InvalidArgumentException('The _meta data passed to the subscription must be an array.');
-            }
-            $payload[self::API_NAME_META] = $_meta;
+        $payload = [self::API_NAME_SUBSCRIPTION => $subscription->getFormData()];
+        if (!empty($metadata)) {
+            $payload[self::API_NAME_META] = $metadata;
         }
         $response = $this->httpClient->post($url, $payload);
         return $this->retrieveItem($response, self::API_NAME_SUBSCRIPTION, $subscription);


### PR DESCRIPTION
Supports:

* `_meta[order_details]` inside `/services/v2/subscription.json` call
* `/services/v2/order-details.json` endpoint
* `/services/v2/order-details/create-or-update.json` endpoint