### PR TITLE
Bump versions for M2.4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": ">=5.5",
-    "guzzlehttp/guzzle": "~6.0.1|~6.1|~6.2"
+    "guzzlehttp/guzzle": "~7.4.5"
   },
   "require-dev": {
     "monolog/monolog": "^1.16.0"


### PR DESCRIPTION
Upgrade to a version of guzzle which is compatible with PHP8 & Magento 2.4.4.