### PR TITLE
#197 - Add additional fields to payment profile on Payment Fields.

### DIFF
--- a/src/SubscribePro/Service/PaymentProfile/PaymentProfile.php
+++ b/src/SubscribePro/Service/PaymentProfile/PaymentProfile.php
@@ -107,6 +107,9 @@ class PaymentProfile extends DataObject implements PaymentProfileInterface
         self::CREDITCARD_MONTH => false,
         self::CREDITCARD_YEAR => false,
         self::BILLING_ADDRESS => false,
+        self::CREDITCARD_FIRST_DIGITS => false,
+        self::CREDITCARD_LAST_DIGITS => false,
+        self::CREDITCARD_TYPE => false,
     ];
 
     /**


### PR DESCRIPTION
Feat: Add additional fields to payment profile on Payment Fields.

Refs: #197

Original task https://github.com/subscribepro/subscribepro-magento2-ext/issues/197